### PR TITLE
Correct remotekeys endpoint

### DIFF
--- a/swarm/validator/validator.py
+++ b/swarm/validator/validator.py
@@ -49,7 +49,8 @@ class Validator():
             print('Loaded keystores into validator successfuly')
         
     def load_remote_keys(self, keystores: List[dict], remote_signer_url: str) -> None:
-        validator_endpoint = f'http://localhost:{self.keymanager_port}/eth/v1/keystores'
+        validator_remotekeys_endpoint = f'http://localhost:{self.keymanager_port}/eth/v1/remotekeys'
+        validator_keystores_endpoint = f'http://localhost:{self.keymanager_port}/eth/v1/keystores'
         validator_data = {
             'remote_keys': []
         }
@@ -60,7 +61,7 @@ class Validator():
 
         with SSHTunnel(self.ssh_address, self.keymanager_port):
             # check if the keys are deployed
-            response = requests.get(url=validator_endpoint, headers=self.headers)
+            response = requests.get(url=validator_keystores_endpoint, headers=self.headers)
             response_json = response.json()
             
             added_keylist = [k['validating_pubkey'] for k in response_json['data']]
@@ -69,7 +70,7 @@ class Validator():
             if any([x in added_keylist for x in new_keylist]):
                 raise ValidatorLoadException('The submitted keys are already loaded into the validator client.')
 
-            response = requests.post(url=validator_endpoint, headers=self.headers, json=validator_data)
+            response = requests.post(url=validator_remotekeys_endpoint, headers=self.headers, json=validator_data)
             print(response.json(), flush=True) 
             if response.status_code != 200:
                 raise ValidatorLoadException(f'Submission of keys to validator client unsuccessful. Status code: {response.status_code}')


### PR DESCRIPTION
I have been struggling with deploying validators with the remote signer setup.

I was getting this error:

```
python -m swarm deploy --n_keys 1 --index 201 --remote_sign
Enter mnemonic: [redacted]
creating 1 keys...
Success!
{'data': [{'status': 'imported', 'message': None}]}
Loaded keystores into remote signer successfuly
{'code': 400, 'message': 'BAD_REQUEST: body deserialize error: Request body deserialize error: unknown field `remote_keys`, expected one of `keystores`, `passwords`, `slashing_protection` at line 1 column 14', 'stacktraces': []}
Submission of keys to validator client unsuccessful. Status code: 400 <traceback object at 0x103a5edc0>
Error: failed to load keys into validator client: Submission of keys to validator client unsuccessful. Status code: 400
```

At first I got paranoid and tested it out both with our new testnet validator as well as our old validator, but the issue persisted.

After some troubleshooting and research, I realized the `remote_keys` key is expected in a different Keymanager endpoint. Or at least that's according to [these docs](https://ethereum.github.io/keymanager-APIs/#/Local%20Key%20Manager/importKeystores).

Changing the endpoint used in the `load_remote_keys` method from `/eth/v1/keystores` to `/eth/v1/remotekeys` fixed it:

```
python -m swarm deploy --n_keys 1 --index 202 --remote_sign
Enter mnemonic: [redacted]
creating 1 keys...
Success!
{'data': [{'status': 'imported', 'message': None}]}
Loaded keystores into remote signer successfuly
{'data': [{'status': 'imported'}]}
Loaded remote keys into validator successfuly
<swarm.connection.connection.NodeWSConnection object at 0x1024dfa10>
Bond is 1.5 ETH for 1 keys
Submitting keys....
Serving local signing app on http://localhost:8000
127.0.0.1 - - [24/Oct/2024 18:27:33] "GET / HTTP/1.1" 304 -
127.0.0.1 - - [24/Oct/2024 18:27:34] "GET /params HTTP/1.1" 200 -
127.0.0.1 - - [24/Oct/2024 18:27:37] "GET /done?txHash=0x89c5e9e17f2b92a3e227f106aa9a183fa55f3da12b97c7254d2a475551fa4376 HTTP/1.1" 200 -
Shutting down signing app.
Tx hash:  0x89c5e9e17f2b92a3e227f106aa9a183fa55f3da12b97c7254d2a475551fa4376
Uploaded keys and sent ETH to CSM sucessfully
```

I'm pretty sure we had tested this so I'm very confused... Did I miss anything?